### PR TITLE
Add --version flag to CLI

### DIFF
--- a/src/haunt/cli.py
+++ b/src/haunt/cli.py
@@ -6,6 +6,7 @@ from typing import Optional
 import typer
 from typing_extensions import Annotated
 
+from haunt import __version__
 from haunt.exceptions import ConflictError
 from haunt.exceptions import HauntError
 from haunt.exceptions import PackageAlreadyInstalledError
@@ -23,6 +24,26 @@ from haunt.output import print_uninstall_plan
 from haunt.registry import Registry
 
 app = typer.Typer(help="Symlink dotfiles manager")
+
+
+def version_callback(value: bool) -> None:
+    """Print version and exit."""
+    if value:
+        typer.echo(f"haunt {__version__}")
+        raise typer.Exit()
+
+
+@app.callback()
+def main_callback(
+    version: Annotated[
+        Optional[bool],
+        typer.Option(
+            "--version", callback=version_callback, is_eager=True, help="Show version"
+        ),
+    ] = None,
+) -> None:
+    """Symlink dotfiles manager."""
+    pass
 
 
 @app.command()


### PR DESCRIPTION
## Summary

Adds support for the `--version` flag to display the installed version of haunt.

## Changes

- Implemented `--version` flag using Typer's callback pattern with `is_eager=True`
- Version is read from package metadata via `importlib.metadata.version()`
- Flag is available at root level before any subcommand (e.g., `haunt --version`)

## Testing

- All 103 existing tests pass
- Manually verified `haunt --version` displays: `haunt 0.2.0.dev0`
- Type checking (mypy) and linting (ruff) pass

Fixes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)