### PR TITLE
Remove unused InvalidPackageError exception

### DIFF
--- a/src/haunt/exceptions.py
+++ b/src/haunt/exceptions.py
@@ -39,10 +39,6 @@ class ConflictError(HauntError):
         super().__init__(f"Conflicts detected: {conflict_paths}")
 
 
-class InvalidPackageError(HauntError):
-    """Package directory is invalid (empty, paths escape target, etc.)."""
-
-
 class RegistryValidationError(HauntError):
     """Registry file is invalid or malformed."""
 


### PR DESCRIPTION
Removes the unused InvalidPackageError class. It was never raised anywhere in the codebase.

Fixes #5