### PR TITLE
Add directory validation to prevent problematic installs

### DIFF
--- a/src/haunt/cli.py
+++ b/src/haunt/cli.py
@@ -97,6 +97,9 @@ def install(
             err=True,
         )
         raise typer.Exit(1)
+    except ValueError as e:
+        typer.secho(f"✗ {e}", fg=typer.colors.RED, bold=True, err=True)
+        raise typer.Exit(1)
     except OSError as e:
         typer.secho(
             f"✗ Filesystem error: {e}", fg=typer.colors.RED, bold=True, err=True

--- a/src/haunt/operations/install.py
+++ b/src/haunt/operations/install.py
@@ -18,6 +18,7 @@ from haunt.models import PackageEntry
 from haunt.models import Symlink
 from haunt.operations.paths import normalize_package_dir
 from haunt.operations.paths import normalize_target_dir
+from haunt.operations.paths import validate_install_directories
 from haunt.registry import Registry
 
 
@@ -39,10 +40,14 @@ def compute_install_plan(
     Raises:
         FileNotFoundError: If package_dir does not exist
         NotADirectoryError: If package_dir is not a directory
+        ValueError: If package_dir is /, or if target_dir equals or is inside package_dir
     """
     # Normalize paths to absolute
     package_dir = normalize_package_dir(package_dir)
     target_dir = normalize_target_dir(target_dir)
+
+    # Validate directory relationships
+    validate_install_directories(package_dir, target_dir)
 
     package_name = package_dir.name
     symlinks_to_create: list[Symlink] = []

--- a/src/haunt/operations/paths.py
+++ b/src/haunt/operations/paths.py
@@ -36,3 +36,26 @@ def normalize_target_dir(target_dir: Path) -> Path:
         Absolute path to target directory
     """
     return target_dir.resolve()
+
+
+def validate_install_directories(package_dir: Path, target_dir: Path) -> None:
+    """Validate that package and target directories have a valid relationship.
+
+    Args:
+        package_dir: Normalized package directory (must be absolute)
+        target_dir: Normalized target directory (must be absolute)
+
+    Raises:
+        ValueError: If package_dir is /, or if target_dir equals or is inside package_dir
+    """
+    if package_dir == Path("/"):
+        raise ValueError("Package directory cannot be filesystem root (/)")
+    if package_dir == target_dir:
+        raise ValueError(
+            f"Package directory and target directory cannot be the same: {package_dir}"
+        )
+    if target_dir.is_relative_to(package_dir):
+        raise ValueError(
+            f"Target directory cannot be inside package directory: "
+            f"target={target_dir}, package={package_dir}"
+        )

--- a/tests/operations/test_paths.py
+++ b/tests/operations/test_paths.py
@@ -6,6 +6,7 @@ import pytest
 
 from haunt.operations import normalize_package_dir
 from haunt.operations import normalize_target_dir
+from haunt.operations.paths import validate_install_directories
 
 
 class TestNormalizePackageDir:
@@ -86,3 +87,41 @@ class TestNormalizeTargetDir:
         result = normalize_target_dir(nonexistent)
 
         assert result.is_absolute()
+
+
+class TestValidateInstallDirectories:
+    """Tests for validate_install_directories()."""
+
+    def test_raises_when_package_is_root(self, tmp_path):
+        """Test that package directory cannot be filesystem root."""
+        target_dir = tmp_path / "target"
+
+        with pytest.raises(
+            ValueError, match="Package directory cannot be filesystem root"
+        ):
+            validate_install_directories(Path("/"), target_dir)
+
+    def test_raises_when_target_equals_package(self, tmp_path):
+        """Test that target and package directories cannot be the same."""
+        package_dir = tmp_path / "package"
+
+        with pytest.raises(ValueError, match="cannot be the same"):
+            validate_install_directories(package_dir, package_dir)
+
+    def test_raises_when_target_inside_package(self, tmp_path):
+        """Test that target directory cannot be inside package directory."""
+        package_dir = tmp_path / "package"
+        target_dir = package_dir / "subdir"
+
+        with pytest.raises(
+            ValueError, match="Target directory cannot be inside package directory"
+        ):
+            validate_install_directories(package_dir, target_dir)
+
+    def test_valid_directories_do_not_raise(self, tmp_path):
+        """Test that valid directory configurations do not raise."""
+        package_dir = tmp_path / "package"
+        target_dir = tmp_path / "target"
+
+        # Should not raise
+        validate_install_directories(package_dir, target_dir)


### PR DESCRIPTION
Adds validation in `validate_install_directories()` to prevent:
- Using filesystem root (/) as package directory
- Target directory equaling package directory
- Target directory inside package directory

Fixes #4