### PR TITLE
Adopt modern Python tooling recommendations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,12 @@
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.4
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,9 +45,14 @@ dev = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+addopts = ["--cov=src", "--cov-report=term-missing"]
 
 [tool.ruff]
 line-length = 88
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B", "C4", "UP"]
 
 [tool.ruff.lint.isort]
 force-single-line = true

--- a/src/haunt/cli.py
+++ b/src/haunt/cli.py
@@ -1,10 +1,9 @@
 """Command-line interface for haunt."""
 
 from pathlib import Path
-from typing import Optional
+from typing import Annotated
 
 import typer
-from typing_extensions import Annotated
 
 from haunt import __version__
 from haunt.exceptions import ConflictError
@@ -36,7 +35,7 @@ def version_callback(value: bool) -> None:
 @app.callback()
 def main_callback(
     version: Annotated[
-        Optional[bool],
+        bool | None,
         typer.Option(
             "--version", callback=version_callback, is_eager=True, help="Show version"
         ),
@@ -50,7 +49,7 @@ def main_callback(
 def install(
     package: Annotated[Path, typer.Argument(help="Package directory to install")],
     target: Annotated[
-        Optional[Path],
+        Path | None,
         typer.Argument(help="Target directory for symlinks (default: $HOME)"),
     ] = None,
     dry_run: Annotated[
@@ -73,45 +72,47 @@ def install(
             execute_install_plan(plan, Registry.default_path(), on_conflict=on_conflict)
     except PackageAlreadyInstalledError as e:
         typer.secho(f"✗ {e}", fg=typer.colors.RED, bold=True, err=True)
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
     except ConflictError as e:
         print_conflict_error(e, on_conflict)
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
     except (RegistryValidationError, RegistryVersionError) as e:
         typer.secho(f"✗ Registry error: {e}", fg=typer.colors.RED, bold=True, err=True)
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
     except PermissionError as e:
         typer.secho(
             f"✗ Permission denied: {e}", fg=typer.colors.RED, bold=True, err=True
         )
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
     except FileExistsError as e:
         typer.secho(
-            f"✗ File exists (filesystem probably changed between planning and execution): {e}",
+            f"✗ File exists (filesystem changed between planning and execution): {e}",
             fg=typer.colors.RED,
             bold=True,
             err=True,
         )
         typer.secho(
-            "   Warning: Package may be partially installed. Check filesystem and registry manually.",
+            "   Warning: Package may be partially installed. Check "
+            "filesystem and registry manually.",
             err=True,
         )
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
     except ValueError as e:
         typer.secho(f"✗ {e}", fg=typer.colors.RED, bold=True, err=True)
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
     except OSError as e:
         typer.secho(
             f"✗ Filesystem error: {e}", fg=typer.colors.RED, bold=True, err=True
         )
         typer.secho(
-            "   Warning: Package may be partially installed. Check filesystem and registry manually.",
+            "   Warning: Package may be partially installed. Check "
+            "filesystem and registry manually.",
             err=True,
         )
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
     except HauntError as e:
         typer.secho(f"✗ Error: {e}", fg=typer.colors.RED, bold=True, err=True)
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
 
 
 @app.command()
@@ -130,27 +131,28 @@ def uninstall(
             execute_uninstall_plan(plan, Registry.default_path())
     except PackageNotFoundError as e:
         typer.secho(f"✗ {e}", fg=typer.colors.RED, bold=True, err=True)
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
     except (RegistryValidationError, RegistryVersionError) as e:
         typer.secho(f"✗ Registry error: {e}", fg=typer.colors.RED, bold=True, err=True)
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
     except PermissionError as e:
         typer.secho(
             f"✗ Permission denied: {e}", fg=typer.colors.RED, bold=True, err=True
         )
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
     except OSError as e:
         typer.secho(
             f"✗ Filesystem error: {e}", fg=typer.colors.RED, bold=True, err=True
         )
         typer.secho(
-            "   Warning: Package may be partially uninstalled. Check filesystem and registry manually.",
+            "   Warning: Package may be partially uninstalled. Check "
+            "filesystem and registry manually.",
             err=True,
         )
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
     except HauntError as e:
         typer.secho(f"✗ Error: {e}", fg=typer.colors.RED, bold=True, err=True)
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
 
 
 def main() -> None:

--- a/src/haunt/files/cleanup.py
+++ b/src/haunt/files/cleanup.py
@@ -26,8 +26,8 @@ def remove_empty_directories(target_dir: Path, file_paths: list[Path]) -> list[P
         # Validate that file_path is under target_dir
         try:
             file_path.relative_to(target_dir)
-        except ValueError:
-            raise ValueError(f"{file_path} is not under {target_dir}")
+        except ValueError as e:
+            raise ValueError(f"{file_path} is not under {target_dir}") from e
 
         # Get the parent directory of this file
         current = file_path.parent

--- a/src/haunt/files/discover.py
+++ b/src/haunt/files/discover.py
@@ -14,7 +14,7 @@ def discover_files(package_dir: Path) -> list[Path]:
         registry output (makes diffs/version control cleaner).
     """
     files = []
-    for dirpath, dirnames, filenames in package_dir.walk():
+    for dirpath, _dirnames, filenames in package_dir.walk():
         for filename in filenames:
             full_path = dirpath / filename
             rel_path = full_path.relative_to(package_dir)

--- a/src/haunt/files/symlinks.py
+++ b/src/haunt/files/symlinks.py
@@ -82,14 +82,16 @@ def create_symlink(symlink: Symlink, force: bool = False) -> None:
 
     Raises:
         IsADirectoryError: If force=True and link_path is a directory
-        FileExistsError: If something exists at link_path (filesystem changed after planning)
+        FileExistsError: If something exists at link_path (filesystem changed
+            after planning)
     """
     if symlink.exists():
         return
 
     # In force mode, remove existing files/symlinks (but not directories)
     if force:
-        # Check if it's a real directory (is_dir follows symlinks, so we need both checks)
+        # Check if it's a real directory (is_dir follows symlinks, so we need
+        # both checks)
         if symlink.link_path.is_dir() and not symlink.link_path.is_symlink():
             raise IsADirectoryError(
                 f"Cannot force-create symlink: {symlink.link_path} is a directory"

--- a/src/haunt/operations/install.py
+++ b/src/haunt/operations/install.py
@@ -1,7 +1,7 @@
 """High-level operations for install and uninstall."""
 
+from datetime import UTC
 from datetime import datetime
-from datetime import timezone
 from pathlib import Path
 
 from haunt.exceptions import ConflictError
@@ -28,8 +28,10 @@ def compute_install_plan(
     """Compute a plan for installing a package.
 
     Args:
-        package_dir: Directory containing files to symlink (will be resolved to absolute)
-        target_dir: Directory where symlinks will be created (will be resolved to absolute)
+        package_dir: Directory containing files to symlink (will be resolved
+            to absolute)
+        target_dir: Directory where symlinks will be created (will be
+            resolved to absolute)
         on_conflict: How to handle conflicts (ABORT, SKIP, or FORCE)
 
     Returns:
@@ -40,7 +42,8 @@ def compute_install_plan(
     Raises:
         FileNotFoundError: If package_dir does not exist
         NotADirectoryError: If package_dir is not a directory
-        ValueError: If package_dir is /, or if target_dir equals or is inside package_dir
+        ValueError: If package_dir is /, or if target_dir equals or is inside
+            package_dir
     """
     # Normalize paths to absolute
     package_dir = normalize_package_dir(package_dir)
@@ -158,7 +161,7 @@ def execute_install_plan(
         package_dir=plan.package_dir,
         target_dir=plan.target_dir,
         symlinks=all_symlinks,
-        installed_at=datetime.now(timezone.utc).isoformat(),
+        installed_at=datetime.now(UTC).isoformat(),
     )
 
     # Update registry (reuse registry loaded earlier)

--- a/src/haunt/operations/paths.py
+++ b/src/haunt/operations/paths.py
@@ -46,7 +46,8 @@ def validate_install_directories(package_dir: Path, target_dir: Path) -> None:
         target_dir: Normalized target directory (must be absolute)
 
     Raises:
-        ValueError: If package_dir is /, or if target_dir equals or is inside package_dir
+        ValueError: If package_dir is /, or if target_dir equals or is inside
+            package_dir
     """
     if package_dir == Path("/"):
         raise ValueError("Package directory cannot be filesystem root (/)")

--- a/src/haunt/operations/uninstall.py
+++ b/src/haunt/operations/uninstall.py
@@ -27,8 +27,10 @@ def compute_uninstall_plan(package_name: str, registry_path: Path) -> UninstallP
     registry = Registry.load(registry_path)
     try:
         entry = registry.packages[package_name]
-    except KeyError:
-        raise PackageNotFoundError(f"Package '{package_name}' not found in registry")
+    except KeyError as e:
+        raise PackageNotFoundError(
+            f"Package '{package_name}' not found in registry"
+        ) from e
 
     symlinks_to_remove = []
     missing_symlinks = []

--- a/src/haunt/registry.py
+++ b/src/haunt/registry.py
@@ -54,7 +54,8 @@ class Registry:
         version = data["version"]
         if version > REGISTRY_VERSION:
             raise RegistryVersionError(
-                f"Registry version {version} is newer than supported version {REGISTRY_VERSION}"
+                f"Registry version {version} is newer than supported version "
+                f"{REGISTRY_VERSION}"
             )
 
         if "packages" not in data:
@@ -83,9 +84,11 @@ class Registry:
             data = json.loads(path.read_text())
             return cls.from_dict(data)
         except json.JSONDecodeError as e:
-            raise RegistryValidationError(f"Invalid JSON in registry: {e}")
+            raise RegistryValidationError(f"Invalid JSON in registry: {e}") from e
         except KeyError as e:
-            raise RegistryValidationError(f"Missing required field in registry: {e}")
+            raise RegistryValidationError(
+                f"Missing required field in registry: {e}"
+            ) from e
 
     def save(self, path: Path | None = None) -> None:
         """Save registry to JSON file atomically.

--- a/tests/files/test_discover.py
+++ b/tests/files/test_discover.py
@@ -2,7 +2,6 @@
 
 from pathlib import Path
 
-
 from haunt.files import discover_files
 
 
@@ -159,7 +158,7 @@ class TestDiscoverFiles:
         assert len(files) == 2
 
     def test_discover_symlink_and_target_in_same_package(self, tmp_path):
-        """Test that both symlink and its target are discovered when both are in package."""
+        """Test that both symlink and target are discovered when in package."""
         package_dir = tmp_path / "package"
         package_dir.mkdir()
 

--- a/tests/operations/test_install.py
+++ b/tests/operations/test_install.py
@@ -213,7 +213,7 @@ class TestComputeInstallPlan:
         assert plan.symlinks_to_create[0].link_path == target_dir / "file1.txt"
 
     def test_force_mode_does_not_include_directory_conflicts(self, tmp_path):
-        """Test that FORCE mode does NOT include directory conflicts in symlinks_to_create."""
+        """Test FORCE mode excludes directory conflicts from symlinks."""
         package_dir = tmp_path / "package"
         package_dir.mkdir()
         (package_dir / "file1.txt").write_text("new")
@@ -518,7 +518,7 @@ class TestExecuteInstallPlan:
         assert "test-package" in registry.packages
 
     def test_raises_for_package_name_collision(self, tmp_path):
-        """Test that installing a package with the same name from different path raises error."""
+        """Test installing package with same name from different path raises."""
         # Two different package directories with the same basename
         package_dir1 = tmp_path / "dotfiles1" / "shell"
         package_dir2 = tmp_path / "dotfiles2" / "shell"
@@ -554,7 +554,7 @@ class TestExecuteInstallPlan:
         assert error.new_path == str(package_dir2)
 
     def test_allows_reinstall_from_same_path(self, tmp_path):
-        """Test that reinstalling a package from the same path is allowed (idempotent)."""
+        """Test reinstalling package from same path is allowed (idempotent)."""
         package_dir = tmp_path / "package"
         target_dir = tmp_path / "target"
         registry_path = tmp_path / "registry.json"


### PR DESCRIPTION
## Summary
Implements recommendations from the [Modern Python Project Setup guide](https://pydevtools.com/handbook/explanation/modern-python-project-setup-guide-for-ai-assistants/)

## Configuration changes
- Add pytest coverage to pyproject.toml (`--cov=src`, `--cov-report=term-missing`)
- Add Ruff lint rules (E, F, I, B, C4, UP) and target-version py312
- Add standard pre-commit hooks (trailing-whitespace, end-of-file-fixer, check-yaml, check-added-large-files)

## Code quality fixes
Fixed violations from new lint rules:
- **B904**: Add explicit exception chaining (`raise ... from e/None`)
- **UP035/UP045**: Modernize type hints (`Optional[X]` → `X | None`)
- **E501**: Fix line length violations (split long lines to ≤88 chars)
- **B007**: Rename unused loop variable (`dirnames` → `_dirnames`)
- **I001**: Clean up import formatting

## Test plan
- [x] All 107 tests pass
- [x] mypy strict checks pass
- [x] ruff checks pass
- [x] pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)