### PR TITLE
Add git-aware file discovery

### DIFF
--- a/src/haunt/files/discover.py
+++ b/src/haunt/files/discover.py
@@ -1,10 +1,32 @@
 """File and directory discovery operations."""
 
+import subprocess
 from pathlib import Path
 
 
-def discover_files(package_dir: Path) -> list[Path]:
-    """Discover all files in package directory.
+def _should_use_git(package_dir: Path) -> bool:
+    """Check if package directory is in a git repository.
+
+    Args:
+        package_dir: Directory to check
+
+    Returns:
+        True if git repo detected, False otherwise
+    """
+    try:
+        subprocess.run(
+            ["git", "rev-parse", "--git-dir"],
+            cwd=package_dir,
+            capture_output=True,
+            check=True,
+        )
+        return True
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False
+
+
+def discover_files_walk(package_dir: Path) -> list[Path]:
+    """Discover all files in package directory using filesystem walk.
 
     Args:
         package_dir: Directory to scan for files
@@ -21,3 +43,52 @@ def discover_files(package_dir: Path) -> list[Path]:
             files.append(rel_path)
 
     return sorted(files)
+
+
+def discover_files_git(package_dir: Path) -> list[Path]:
+    """Discover tracked files in git repository using git ls-files.
+
+    Args:
+        package_dir: Directory to scan for files (must be in a git repo)
+
+    Returns:
+        Sorted list of relative paths to all tracked files, excluding
+        .gitmodules. Includes files in submodules.
+    """
+    result = subprocess.run(
+        ["git", "ls-files", "-z", "--recurse-submodules"],
+        cwd=package_dir,
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+
+    files = []
+    for file_str in result.stdout.split("\0"):
+        if not file_str:  # Skip empty strings from trailing null
+            continue
+        file_path = Path(file_str)
+        if file_path.name == ".gitmodules":  # Filter out .gitmodules
+            continue
+        files.append(file_path)
+
+    return sorted(files)
+
+
+def discover_files(package_dir: Path) -> list[Path]:
+    """Discover all files in package directory.
+
+    Uses git ls-files if package is in a git repository (respects .gitignore,
+    includes submodules, excludes .gitmodules). Falls back to filesystem walk
+    otherwise.
+
+    Args:
+        package_dir: Directory to scan for files
+
+    Returns:
+        Sorted list of relative paths to all files. Sorted for deterministic
+        registry output (makes diffs/version control cleaner).
+    """
+    if _should_use_git(package_dir):
+        return discover_files_git(package_dir)
+    return discover_files_walk(package_dir)

--- a/tests/files/test_discover.py
+++ b/tests/files/test_discover.py
@@ -1,19 +1,24 @@
 """Tests for file discovery operations."""
 
+import subprocess
 from pathlib import Path
+from unittest.mock import patch
 
-from haunt.files import discover_files
+from haunt.files.discover import _should_use_git
+from haunt.files.discover import discover_files
+from haunt.files.discover import discover_files_git
+from haunt.files.discover import discover_files_walk
 
 
-class TestDiscoverFiles:
-    """Tests for discover_files()."""
+class TestDiscoverFilesWalk:
+    """Tests for discover_files_walk()."""
 
-    def test_discover_files_in_empty_directory(self, tmp_path):
+    def test_discover_files_walk_in_empty_directory(self, tmp_path):
         """Test discovering files in an empty directory."""
         package_dir = tmp_path / "package"
         package_dir.mkdir()
 
-        files = discover_files(package_dir)
+        files = discover_files_walk(package_dir)
 
         assert files == []
 
@@ -23,7 +28,7 @@ class TestDiscoverFiles:
         package_dir.mkdir()
         (package_dir / ".bashrc").touch()
 
-        files = discover_files(package_dir)
+        files = discover_files_walk(package_dir)
 
         assert files == [Path(".bashrc")]
 
@@ -35,7 +40,7 @@ class TestDiscoverFiles:
         (package_dir / ".vimrc").touch()
         (package_dir / ".profile").touch()
 
-        files = discover_files(package_dir)
+        files = discover_files_walk(package_dir)
 
         assert len(files) == 3
         assert Path(".bashrc") in files
@@ -56,7 +61,7 @@ class TestDiscoverFiles:
         nvim_dir.mkdir()
         (nvim_dir / "init.vim").touch()
 
-        files = discover_files(package_dir)
+        files = discover_files_walk(package_dir)
 
         assert len(files) == 3
         assert Path(".bashrc") in files
@@ -73,7 +78,7 @@ class TestDiscoverFiles:
         subdir.mkdir()
         (subdir / "nested.txt").touch()
 
-        files = discover_files(package_dir)
+        files = discover_files_walk(package_dir)
 
         assert len(files) == 2
         assert Path("file.txt") in files
@@ -89,7 +94,7 @@ class TestDiscoverFiles:
         (package_dir / "apple").touch()
         (package_dir / "middle").touch()
 
-        files = discover_files(package_dir)
+        files = discover_files_walk(package_dir)
 
         assert files == sorted(files)
 
@@ -99,7 +104,7 @@ class TestDiscoverFiles:
         package_dir.mkdir()
         (package_dir / "file.txt").touch()
 
-        files = discover_files(package_dir)
+        files = discover_files_walk(package_dir)
 
         # Should be relative, not absolute
         assert files[0] == Path("file.txt")
@@ -112,7 +117,7 @@ class TestDiscoverFiles:
         (package_dir / ".hidden").touch()
         (package_dir / "visible").touch()
 
-        files = discover_files(package_dir)
+        files = discover_files_walk(package_dir)
 
         assert Path(".hidden") in files
         assert Path("visible") in files
@@ -130,7 +135,7 @@ class TestDiscoverFiles:
         link = package_dir / "link.txt"
         link.symlink_to(external_file)
 
-        files = discover_files(package_dir)
+        files = discover_files_walk(package_dir)
 
         assert Path("link.txt") in files
 
@@ -148,7 +153,7 @@ class TestDiscoverFiles:
         (package_dir / "dir_link").symlink_to(external_dir)
         (package_dir / "normal.txt").touch()
 
-        files = discover_files(package_dir)
+        files = discover_files_walk(package_dir)
 
         # Symlink to directory should be discovered
         assert Path("dir_link") in files
@@ -170,9 +175,225 @@ class TestDiscoverFiles:
         link_file = package_dir / ".bashrc"
         link_file.symlink_to(".bash_profile")
 
-        files = discover_files(package_dir)
+        files = discover_files_walk(package_dir)
 
         # Both the symlink and its target should be discovered
         assert Path(".bashrc") in files
         assert Path(".bash_profile") in files
         assert len(files) == 2
+
+
+class TestShouldUseGit:
+    """Tests for _should_use_git()."""
+
+    def test_returns_true_for_git_repo(self, tmp_path):
+        """Test that _should_use_git returns True for git repository."""
+        package_dir = tmp_path / "package"
+        package_dir.mkdir()
+
+        # Initialize git repo
+        subprocess.run(["git", "init"], cwd=package_dir, capture_output=True)
+
+        assert _should_use_git(package_dir) is True
+
+    def test_returns_false_for_non_git_directory(self, tmp_path):
+        """Test that _should_use_git returns False for non-git directory."""
+        package_dir = tmp_path / "package"
+        package_dir.mkdir()
+
+        assert _should_use_git(package_dir) is False
+
+    def test_returns_true_for_subdirectory_of_git_repo(self, tmp_path):
+        """Test _should_use_git returns True when package is subdirectory."""
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+
+        # Initialize git repo at root
+        subprocess.run(["git", "init"], cwd=repo_root, capture_output=True)
+
+        # Check subdirectory
+        package_dir = repo_root / "subdir"
+        package_dir.mkdir()
+
+        assert _should_use_git(package_dir) is True
+
+    def test_returns_false_when_git_not_on_path(self, tmp_path):
+        """Test _should_use_git returns False when git command not found."""
+        package_dir = tmp_path / "package"
+        package_dir.mkdir()
+
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            assert _should_use_git(package_dir) is False
+
+    def test_returns_false_when_git_fails(self, tmp_path):
+        """Test _should_use_git returns False when git command fails."""
+        package_dir = tmp_path / "package"
+        package_dir.mkdir()
+
+        with patch(
+            "subprocess.run", side_effect=subprocess.CalledProcessError(1, "git")
+        ):
+            assert _should_use_git(package_dir) is False
+
+
+class TestDiscoverFilesGit:
+    """Tests for discover_files_git()."""
+
+    def test_discovers_tracked_files_only(self, tmp_path):
+        """Test that only git-tracked files are discovered."""
+        package_dir = tmp_path / "package"
+        package_dir.mkdir()
+
+        # Initialize git repo
+        subprocess.run(["git", "init"], cwd=package_dir, capture_output=True)
+
+        # Create files
+        (package_dir / "tracked.txt").write_text("tracked")
+        (package_dir / "untracked.txt").write_text("untracked")
+
+        # Track only one file
+        subprocess.run(["git", "add", "tracked.txt"], cwd=package_dir)
+
+        files = discover_files_git(package_dir)
+
+        assert Path("tracked.txt") in files
+        assert Path("untracked.txt") not in files
+
+    def test_respects_gitignore(self, tmp_path):
+        """Test that .gitignore rules are respected."""
+        package_dir = tmp_path / "package"
+        package_dir.mkdir()
+
+        # Initialize git repo
+        subprocess.run(["git", "init"], cwd=package_dir, capture_output=True)
+
+        # Create .gitignore
+        (package_dir / ".gitignore").write_text("*.log\n")
+
+        # Create files
+        (package_dir / "file.txt").touch()
+        (package_dir / "ignored.log").touch()
+
+        # Add all files
+        subprocess.run(["git", "add", "-A"], cwd=package_dir, capture_output=True)
+
+        files = discover_files_git(package_dir)
+
+        assert Path("file.txt") in files
+        assert Path("ignored.log") not in files
+        # .gitignore itself should be tracked
+        assert Path(".gitignore") in files
+
+    def test_filters_out_gitmodules(self, tmp_path):
+        """Test that .gitmodules is filtered out."""
+        package_dir = tmp_path / "package"
+        package_dir.mkdir()
+
+        # Initialize git repo
+        subprocess.run(["git", "init"], cwd=package_dir, capture_output=True)
+
+        # Create and track .gitmodules in root and subdirectory
+        (package_dir / ".gitmodules").write_text("[submodule]\n")
+        subdir = package_dir / "subdir"
+        subdir.mkdir()
+        (subdir / ".gitmodules").write_text("[submodule]\n")
+        (package_dir / "file.txt").touch()
+
+        subprocess.run(["git", "add", "-A"], cwd=package_dir, capture_output=True)
+
+        files = discover_files_git(package_dir)
+
+        assert Path(".gitmodules") not in files
+        assert Path("subdir/.gitmodules") not in files
+        assert Path("file.txt") in files
+
+    def test_discovers_files_in_subdirectories(self, tmp_path):
+        """Test that files in subdirectories are discovered."""
+        package_dir = tmp_path / "package"
+        package_dir.mkdir()
+
+        # Initialize git repo
+        subprocess.run(["git", "init"], cwd=package_dir, capture_output=True)
+
+        # Create nested structure
+        config_dir = package_dir / ".config"
+        config_dir.mkdir()
+        (config_dir / "settings.json").touch()
+
+        subprocess.run(["git", "add", "-A"], cwd=package_dir, capture_output=True)
+
+        files = discover_files_git(package_dir)
+
+        assert Path(".config/settings.json") in files
+
+    def test_returns_sorted_list(self, tmp_path):
+        """Test that files are returned in sorted order."""
+        package_dir = tmp_path / "package"
+        package_dir.mkdir()
+
+        # Initialize git repo
+        subprocess.run(["git", "init"], cwd=package_dir, capture_output=True)
+
+        # Create files in non-sorted order
+        (package_dir / "zebra").touch()
+        (package_dir / "apple").touch()
+        (package_dir / "middle").touch()
+
+        subprocess.run(["git", "add", "-A"], cwd=package_dir, capture_output=True)
+
+        files = discover_files_git(package_dir)
+
+        assert files == sorted(files)
+
+
+class TestDiscoverFiles:
+    """Tests for discover_files() wrapper."""
+
+    def test_uses_git_for_git_repo(self, tmp_path):
+        """Test that git method is used for git repositories."""
+        package_dir = tmp_path / "package"
+        package_dir.mkdir()
+
+        # Initialize git repo
+        subprocess.run(["git", "init"], cwd=package_dir, capture_output=True)
+
+        # Create files
+        (package_dir / ".gitignore").write_text("*.log\n")
+        (package_dir / "file.txt").touch()
+        (package_dir / "ignored.log").touch()
+
+        subprocess.run(["git", "add", "-A"], cwd=package_dir, capture_output=True)
+
+        files = discover_files(package_dir)
+
+        # Should use git (respects .gitignore)
+        assert Path("file.txt") in files
+        assert Path("ignored.log") not in files
+
+    def test_uses_walk_for_non_git_directory(self, tmp_path):
+        """Test that walk method is used for non-git directories."""
+        package_dir = tmp_path / "package"
+        package_dir.mkdir()
+
+        # Create files
+        (package_dir / ".gitignore").write_text("*.log\n")
+        (package_dir / "file.txt").touch()
+        (package_dir / "ignored.log").touch()
+
+        files = discover_files(package_dir)
+
+        # Should use walk (does not respect .gitignore)
+        assert Path("file.txt") in files
+        assert Path("ignored.log") in files
+        assert Path(".gitignore") in files
+
+    def test_falls_back_to_walk_when_git_not_available(self, tmp_path):
+        """Test fallback to walk when git is not on PATH."""
+        package_dir = tmp_path / "package"
+        package_dir.mkdir()
+        (package_dir / "file.txt").touch()
+
+        with patch("haunt.files.discover._should_use_git", return_value=False):
+            files = discover_files(package_dir)
+
+        assert Path("file.txt") in files


### PR DESCRIPTION
## Summary
Implements #9: Use `git ls-files` for git repositories to automatically respect `.gitignore` and exclude `.git` directory.

## Changes
Refactored `discover_files()` into three functions:
- `discover_files_walk()`: Original `Path.walk()` implementation
- `discover_files_git()`: New `git ls-files` implementation  
- `discover_files()`: Wrapper that delegates based on git detection
- `_should_use_git()`: Helper to detect git repos via `git rev-parse --git-dir`

## Behavior
- **Git repo detected**: Use `git ls-files -z --recurse-submodules`, filter out `.gitmodules`
- **Not a git repo OR git not on PATH**: Fall back to `Path.walk()`
- Automatically respects `.gitignore` when using git
- Discovers files in submodules

## Testing
- 13 new tests added (120 total, all passing)
- 100% coverage for discover.py
- Overall coverage increased from 65% to 67%

## Test plan
- [x] All 120 tests pass
- [x] ruff checks pass
- [x] mypy strict checks pass
- [x] Tested `.gitmodules` filtering in root and subdirectories

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)