### PR TITLE
Add list command to view installed packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,59 @@ haunt uninstall [OPTIONS] PACKAGE
 - `PACKAGE` - package name to uninstall (required)
 - `--dry-run, -n` - show what would happen without doing it
 
+### `haunt list`
+
+```bash
+haunt list [OPTIONS] [PACKAGE]
+```
+
+List installed packages with their symlinks.
+
+- `PACKAGE` - show only this package (optional, shows all if omitted)
+- `--verbose, -v` - show all symlinks with status validation
+
+**Example output:**
+
+```bash
+$ haunt list
+dotfiles
+  Package: ~/dotfiles
+  Target: ~/
+  Installed: 2025-11-12 13:45:23
+  Symlinks: 3
+
+nvim-config
+  Package: ~/nvim-config
+  Target: ~/.config
+  Installed: 2025-11-12 14:30:15
+  Symlinks: 5
+```
+
+**Verbose mode** checks each symlink and reports issues:
+
+```bash
+$ haunt list --verbose dotfiles
+dotfiles
+  Package: ~/dotfiles
+  Target: ~/
+  Installed: 2025-11-12 13:45:23
+  Symlinks:
+    Correct
+      ~/.bashrc -> ~/dotfiles/.bashrc
+    Inconsistent with Registry
+      ~/.vimrc -> ~/dotfiles/.vimrc (link missing)
+      ~/.zshrc -> /other/file (expected ~/dotfiles/.zshrc)
+      ~/.profile -> ~/dotfiles/.profile (source file missing)
+
+  To fix inconsistent symlinks:
+    haunt install ~/dotfiles ~/
+```
+
+Inconsistent symlink types:
+- `(link missing)`: symlink doesn't exist at expected location
+- `(expected ...)`: symlink points to wrong target
+- `(source file missing)`: symlink exists but source file is gone
+
 ## Conflict handling
 
 By default haunt aborts on any conflict:

--- a/src/haunt/_cli/cli.py
+++ b/src/haunt/_cli/cli.py
@@ -8,7 +8,9 @@ import typer
 from haunt import __version__
 from haunt._cli.output import print_conflict_error
 from haunt._cli.output import print_install_plan
+from haunt._cli.output import print_package_list
 from haunt._cli.output import print_uninstall_plan
+from haunt._registry import Registry
 from haunt.exceptions import ConflictError
 from haunt.exceptions import HauntError
 from haunt.exceptions import PackageAlreadyInstalledError
@@ -108,6 +110,32 @@ def install(
             "filesystem and registry manually.",
             err=True,
         )
+        raise typer.Exit(1) from None
+    except HauntError as e:
+        typer.secho(f"✗ Error: {e}", fg=typer.colors.RED, bold=True, err=True)
+        raise typer.Exit(1) from None
+
+
+@app.command()
+def list(
+    package: Annotated[
+        str | None,
+        typer.Argument(help="Show only this package (optional)"),
+    ] = None,
+    verbose: Annotated[
+        bool,
+        typer.Option("--verbose", "-v", help="Show all symlinks with status"),
+    ] = False,
+) -> None:
+    """List installed packages."""
+    try:
+        registry = Registry()
+        print_package_list(registry, package_name=package, verbose=verbose)
+    except PackageNotFoundError as e:
+        typer.secho(f"✗ {e}", fg=typer.colors.RED, bold=True, err=True)
+        raise typer.Exit(1) from None
+    except (RegistryValidationError, RegistryVersionError) as e:
+        typer.secho(f"✗ Registry error: {e}", fg=typer.colors.RED, bold=True, err=True)
         raise typer.Exit(1) from None
     except HauntError as e:
         typer.secho(f"✗ Error: {e}", fg=typer.colors.RED, bold=True, err=True)

--- a/src/haunt/models.py
+++ b/src/haunt/models.py
@@ -59,6 +59,40 @@ class Symlink:
         actual_target = self.link_path.readlink()
         return self.points_to(actual_target)
 
+    def is_missing(self) -> bool:
+        """Check if the symlink doesn't exist at link_path.
+
+        Returns:
+            True if link_path doesn't exist at all
+        """
+        return not self.link_path.exists(follow_symlinks=False)
+
+    def is_modified(self) -> bool:
+        """Check if symlink exists but points to wrong target.
+
+        Returns:
+            True if link_path exists but doesn't point to source_path
+        """
+        return self.link_path.exists(follow_symlinks=False) and not self.exists()
+
+    def source_exists(self) -> bool:
+        """Check if the source file exists.
+
+        Returns:
+            True if source_path exists
+        """
+        return self.source_path.exists()
+
+    def get_actual_target(self) -> Path | None:
+        """Get the actual target the symlink points to.
+
+        Returns:
+            The path the symlink points to, or None if link_path is not a symlink
+        """
+        if not self.link_path.is_symlink():
+            return None
+        return self.link_path.readlink()
+
 
 @dataclass
 class PackageEntry:

--- a/src/haunt/operations/install.py
+++ b/src/haunt/operations/install.py
@@ -1,6 +1,5 @@
 """High-level operations for install and uninstall."""
 
-from datetime import UTC
 from datetime import datetime
 from pathlib import Path
 
@@ -151,7 +150,7 @@ def apply_install(
         package_dir=plan.package_dir,
         target_dir=plan.target_dir,
         symlinks=all_symlinks,
-        installed_at=datetime.now(UTC).isoformat(),
+        installed_at=datetime.now().astimezone().isoformat(),
     )
 
     registry.packages[plan.package_name] = entry

--- a/tests/files/test_symlinks.py
+++ b/tests/files/test_symlinks.py
@@ -84,6 +84,99 @@ class TestSymlink:
         # Should resolve through the symlink
         assert symlink.points_to(Path("../real_package/file.txt"))
 
+    def test_is_missing_when_link_doesnt_exist(self, tmp_path):
+        """Test is_missing returns True when link doesn't exist."""
+        link_path = tmp_path / "nonexistent.txt"
+        source_path = tmp_path / "source.txt"
+
+        symlink = Symlink(link_path=link_path, source_path=source_path)
+
+        assert symlink.is_missing()
+
+    def test_is_missing_returns_false_when_link_exists(self, tmp_path):
+        """Test is_missing returns False when link exists."""
+        source = tmp_path / "source.txt"
+        source.write_text("content")
+        link = tmp_path / "link.txt"
+        link.symlink_to(source)
+
+        symlink = Symlink(link_path=link, source_path=source)
+
+        assert not symlink.is_missing()
+
+    def test_is_modified_when_link_points_wrong(self, tmp_path):
+        """Test is_modified returns True when link points to wrong target."""
+        source = tmp_path / "source.txt"
+        source.write_text("content")
+        other = tmp_path / "other.txt"
+        other.write_text("other")
+        link = tmp_path / "link.txt"
+        link.symlink_to(other)  # Point to other, not source
+
+        symlink = Symlink(link_path=link, source_path=source)
+
+        assert symlink.is_modified()
+
+    def test_is_modified_returns_false_when_correct(self, tmp_path):
+        """Test is_modified returns False when link is correct."""
+        source = tmp_path / "source.txt"
+        source.write_text("content")
+        link = tmp_path / "link.txt"
+        link.symlink_to(source)
+
+        symlink = Symlink(link_path=link, source_path=source)
+
+        assert not symlink.is_modified()
+
+    def test_is_modified_returns_false_when_missing(self, tmp_path):
+        """Test is_modified returns False when link doesn't exist."""
+        link_path = tmp_path / "nonexistent.txt"
+        source_path = tmp_path / "source.txt"
+
+        symlink = Symlink(link_path=link_path, source_path=source_path)
+
+        assert not symlink.is_modified()
+
+    def test_source_exists_when_file_exists(self, tmp_path):
+        """Test source_exists returns True when source file exists."""
+        source = tmp_path / "source.txt"
+        source.write_text("content")
+        link_path = tmp_path / "link.txt"
+
+        symlink = Symlink(link_path=link_path, source_path=source)
+
+        assert symlink.source_exists()
+
+    def test_source_exists_returns_false_when_missing(self, tmp_path):
+        """Test source_exists returns False when source doesn't exist."""
+        source_path = tmp_path / "nonexistent.txt"
+        link_path = tmp_path / "link.txt"
+
+        symlink = Symlink(link_path=link_path, source_path=source_path)
+
+        assert not symlink.source_exists()
+
+    def test_get_actual_target_returns_target(self, tmp_path):
+        """Test get_actual_target returns the symlink target."""
+        source = tmp_path / "source.txt"
+        source.write_text("content")
+        link = tmp_path / "link.txt"
+        link.symlink_to(source)
+
+        symlink = Symlink(link_path=link, source_path=source)
+
+        assert symlink.get_actual_target() == source
+
+    def test_get_actual_target_returns_none_for_non_symlink(self, tmp_path):
+        """Test get_actual_target returns None for non-symlink."""
+        regular_file = tmp_path / "file.txt"
+        regular_file.write_text("content")
+        source_path = tmp_path / "source.txt"
+
+        symlink = Symlink(link_path=regular_file, source_path=source_path)
+
+        assert symlink.get_actual_target() is None
+
 
 class TestCheckConflict:
     """Tests for check_conflict()."""


### PR DESCRIPTION
Implements `haunt list` command to view installed packages (#3).

## Features

- `haunt list` - shows all installed packages with basic info (name, package dir, target dir, timestamp, symlink count)
- `haunt list <package>` - shows info for a specific package only
- `haunt list --verbose` - validates all symlinks and shows status:
  - Categorizes symlinks as "Correct" or "Inconsistent with Registry"
  - Detects three types of issues:
    - `(link missing)` - symlink doesn't exist at expected location
    - `(expected ...)` - symlink points to wrong target
    - `(source file missing)` - symlink exists but source file is gone
  - Shows helpful fix command when inconsistencies found

## Implementation

- Added four validation methods to `Symlink` model: `is_missing()`, `is_modified()`, `source_exists()`, `get_actual_target()`
- Added `print_package_list()` in output.py for formatted display
- Store timestamps in local timezone (human-readable in JSON)
- Display timestamps converted to current local timezone
- Comprehensive test coverage for new Symlink methods

## Example output

```bash
$ haunt list --verbose dotfiles
dotfiles
  Package: ~/dotfiles
  Target: ~/
  Installed: 2025-11-12 13:45:23
  Symlinks:
    Correct:
      ~/.bashrc -> ~/dotfiles/.bashrc
    Inconsistent with Registry:
      ~/.vimrc -> ~/dotfiles/.vimrc (link missing)
      ~/.zshrc -> /other/file (expected ~/dotfiles/.zshrc)
      ~/.profile -> ~/dotfiles/.profile (source file missing)

  To fix inconsistent symlinks:
    haunt install ~/dotfiles ~/
```