### PR TITLE
Automatic cleanup of unwanted symlinks on reinstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,13 +237,14 @@ haunt install ~/dotfiles
 
 The reinstall detects the file is now missing from its original location and creates the symlink.
 
-To remove a file from a package, delete it from the package directory, then uninstall and reinstall:
+To remove a file from a package, delete it from the package directory, then reinstall:
 
 ```bash
 rm ~/dotfiles/.vimrc
-haunt uninstall dotfiles
 haunt install ~/dotfiles
 ```
+
+The reinstall automatically removes symlinks for files that are no longer in the package.
 
 ## Git Integration
 

--- a/src/haunt/models.py
+++ b/src/haunt/models.py
@@ -24,7 +24,7 @@ class PackageEntryDict(TypedDict):
     installed_at: str
 
 
-@dataclass
+@dataclass(frozen=True)
 class Symlink:
     """A symlink to create or manage."""
 
@@ -50,6 +50,8 @@ class Symlink:
 
     def exists(self) -> bool:
         """Check if link_path exists as a symlink pointing to source_path.
+
+        Note: this does not verify that source_path exists!
 
         Returns:
             True if link_path is a symlink that points to source_path
@@ -201,8 +203,10 @@ class InstallPlan:
     package_name: str
     package_dir: Path
     target_dir: Path
+    wanted_symlinks: list[Symlink]  # All symlinks that should exist after install
     symlinks_to_create: list[Symlink]
     conflicts: list[Conflict]
+    symlinks_to_remove: list[Symlink]  # Orphaned symlinks from previous install
 
 
 @dataclass

--- a/tests/operations/test_unwanted_symlinks.py
+++ b/tests/operations/test_unwanted_symlinks.py
@@ -1,0 +1,334 @@
+"""Unit tests for find_unwanted_symlinks()."""
+
+from datetime import datetime
+
+from haunt._registry import Registry
+from haunt.models import PackageEntry
+from haunt.models import Symlink
+from haunt.operations.install import find_unwanted_symlinks
+
+
+class TestFindUnwantedSymlinks:
+    """Tests for find_unwanted_symlinks()."""
+
+    def test_returns_empty_when_package_not_in_registry(self, tmp_path, monkeypatch):
+        """Test that no unwanted symlinks when package not in registry."""
+        registry_path = tmp_path / "registry.json"
+        monkeypatch.setattr(
+            "haunt._registry.Registry.default_path", lambda cls: registry_path
+        )
+
+        package_dir = tmp_path / "package"
+        target_dir = tmp_path / "target"
+
+        wanted_symlinks = [
+            Symlink(
+                link_path=target_dir / "file1.txt",
+                source_path=package_dir / "file1.txt",
+            ),
+        ]
+
+        result = find_unwanted_symlinks("package", wanted_symlinks)
+
+        assert result == []
+
+    def test_returns_empty_when_no_unwanted(self, tmp_path, monkeypatch):
+        """Test no unwanted symlinks when all old symlinks are still wanted."""
+        registry_path = tmp_path / "registry.json"
+        monkeypatch.setattr(
+            "haunt._registry.Registry.default_path", lambda cls: registry_path
+        )
+
+        package_dir = tmp_path / "package"
+        package_dir.mkdir()
+        target_dir = tmp_path / "target"
+        target_dir.mkdir()
+
+        # Create actual symlinks
+        (package_dir / "file1.txt").write_text("content1")
+        (package_dir / "file2.txt").write_text("content2")
+        (target_dir / "file1.txt").symlink_to(package_dir / "file1.txt")
+        (target_dir / "file2.txt").symlink_to(package_dir / "file2.txt")
+
+        # Set up registry with existing install
+        existing_symlinks = [
+            Symlink(
+                link_path=target_dir / "file1.txt",
+                source_path=package_dir / "file1.txt",
+            ),
+            Symlink(
+                link_path=target_dir / "file2.txt",
+                source_path=package_dir / "file2.txt",
+            ),
+        ]
+
+        registry = Registry(path=registry_path)
+        registry.packages["package"] = PackageEntry(
+            name="package",
+            package_dir=package_dir,
+            target_dir=target_dir,
+            symlinks=existing_symlinks,
+            installed_at=datetime.now().astimezone().isoformat(),
+        )
+        registry.save()
+
+        # Both symlinks are still wanted
+        wanted_symlinks = [
+            Symlink(
+                link_path=target_dir / "file1.txt",
+                source_path=package_dir / "file1.txt",
+            ),
+            Symlink(
+                link_path=target_dir / "file2.txt",
+                source_path=package_dir / "file2.txt",
+            ),
+        ]
+
+        result = find_unwanted_symlinks("package", wanted_symlinks)
+
+        assert result == []
+
+    def test_finds_unwanted_symlink_when_file_removed(self, tmp_path, monkeypatch):
+        """Test that unwanted symlink is found when file removed from package."""
+        registry_path = tmp_path / "registry.json"
+        monkeypatch.setattr(
+            "haunt._registry.Registry.default_path", lambda cls: registry_path
+        )
+
+        package_dir = tmp_path / "package"
+        package_dir.mkdir()
+        target_dir = tmp_path / "target"
+        target_dir.mkdir()
+
+        # Create actual symlinks
+        (package_dir / "file1.txt").write_text("content1")
+        (target_dir / "file1.txt").symlink_to(package_dir / "file1.txt")
+
+        # Set up registry with existing install (had file1 and file2)
+        existing_symlinks = [
+            Symlink(
+                link_path=target_dir / "file1.txt",
+                source_path=package_dir / "file1.txt",
+            ),
+            Symlink(
+                link_path=target_dir / "file2.txt",
+                source_path=package_dir / "file2.txt",
+            ),
+        ]
+
+        registry = Registry(path=registry_path)
+        registry.packages["package"] = PackageEntry(
+            name="package",
+            package_dir=package_dir,
+            target_dir=target_dir,
+            symlinks=existing_symlinks,
+            installed_at=datetime.now().astimezone().isoformat(),
+        )
+        registry.save()
+
+        # Only file2 is wanted now (file1 was removed)
+        wanted_symlinks = [
+            Symlink(
+                link_path=target_dir / "file2.txt",
+                source_path=package_dir / "file2.txt",
+            ),
+        ]
+
+        result = find_unwanted_symlinks("package", wanted_symlinks)
+
+        assert len(result) == 1
+        assert result[0].link_path == target_dir / "file1.txt"
+
+    def test_does_not_include_modified_symlinks(self, tmp_path, monkeypatch):
+        """Test that modified symlinks are not returned as unwanted."""
+        registry_path = tmp_path / "registry.json"
+        monkeypatch.setattr(
+            "haunt._registry.Registry.default_path", lambda cls: registry_path
+        )
+
+        package_dir = tmp_path / "package"
+        package_dir.mkdir()
+        target_dir = tmp_path / "target"
+        target_dir.mkdir()
+
+        # Create symlink pointing to wrong location (user modified)
+        other_file = tmp_path / "other.txt"
+        other_file.write_text("other")
+        (target_dir / "file1.txt").symlink_to(other_file)
+
+        # Set up registry with existing install
+        existing_symlinks = [
+            Symlink(
+                link_path=target_dir / "file1.txt",
+                source_path=package_dir / "file1.txt",
+            ),
+        ]
+
+        registry = Registry(path=registry_path)
+        registry.packages["package"] = PackageEntry(
+            name="package",
+            package_dir=package_dir,
+            target_dir=target_dir,
+            symlinks=existing_symlinks,
+            installed_at=datetime.now().astimezone().isoformat(),
+        )
+        registry.save()
+
+        # file1 is not wanted anymore
+        wanted_symlinks = []
+
+        result = find_unwanted_symlinks("package", wanted_symlinks)
+
+        # Modified symlink should not be in result (user protection)
+        assert result == []
+
+    def test_wanted_symlinks_not_considered_unwanted(self, tmp_path, monkeypatch):
+        """Test that symlinks in wanted set aren't considered unwanted."""
+        registry_path = tmp_path / "registry.json"
+        monkeypatch.setattr(
+            "haunt._registry.Registry.default_path", lambda cls: registry_path
+        )
+
+        package_dir = tmp_path / "package"
+        package_dir.mkdir()
+        target_dir = tmp_path / "target"
+        target_dir.mkdir()
+
+        # Create symlink that already points correctly
+        (package_dir / "file1.txt").write_text("content1")
+        (target_dir / "file1.txt").symlink_to(package_dir / "file1.txt")
+
+        # Set up registry with existing install
+        existing_symlinks = [
+            Symlink(
+                link_path=target_dir / "file1.txt",
+                source_path=package_dir / "file1.txt",
+            ),
+        ]
+
+        registry = Registry(path=registry_path)
+        registry.packages["package"] = PackageEntry(
+            name="package",
+            package_dir=package_dir,
+            target_dir=target_dir,
+            symlinks=existing_symlinks,
+            installed_at=datetime.now().astimezone().isoformat(),
+        )
+        registry.save()
+
+        # file1 is still wanted
+        wanted_symlinks = [
+            Symlink(
+                link_path=target_dir / "file1.txt",
+                source_path=package_dir / "file1.txt",
+            ),
+        ]
+
+        result = find_unwanted_symlinks("package", wanted_symlinks)
+
+        # file1 should not be unwanted (it's still wanted)
+        assert result == []
+
+    def test_handles_multiple_unwanted(self, tmp_path, monkeypatch):
+        """Test finding multiple unwanted symlinks at once."""
+        registry_path = tmp_path / "registry.json"
+        monkeypatch.setattr(
+            "haunt._registry.Registry.default_path", lambda cls: registry_path
+        )
+
+        package_dir = tmp_path / "package"
+        package_dir.mkdir()
+        target_dir = tmp_path / "target"
+        target_dir.mkdir()
+
+        # Create actual symlinks
+        for name in ["file1.txt", "file2.txt", "file3.txt"]:
+            (package_dir / name).write_text("content")
+            (target_dir / name).symlink_to(package_dir / name)
+
+        # Set up registry with existing install
+        existing_symlinks = [
+            Symlink(
+                link_path=target_dir / f"file{i}.txt",
+                source_path=package_dir / f"file{i}.txt",
+            )
+            for i in range(1, 4)
+        ]
+
+        registry = Registry(path=registry_path)
+        registry.packages["package"] = PackageEntry(
+            name="package",
+            package_dir=package_dir,
+            target_dir=target_dir,
+            symlinks=existing_symlinks,
+            installed_at=datetime.now().astimezone().isoformat(),
+        )
+        registry.save()
+
+        # Only file2 is wanted
+        wanted_symlinks = [
+            Symlink(
+                link_path=target_dir / "file2.txt",
+                source_path=package_dir / "file2.txt",
+            ),
+        ]
+
+        result = find_unwanted_symlinks("package", wanted_symlinks)
+
+        # Should find file1 and file3 as unwanted
+        assert len(result) == 2
+        unwanted_paths = {s.link_path for s in result}
+        assert target_dir / "file1.txt" in unwanted_paths
+        assert target_dir / "file3.txt" in unwanted_paths
+        assert target_dir / "file2.txt" not in unwanted_paths
+
+    def test_detects_unwanted_when_source_changes(self, tmp_path, monkeypatch):
+        """Test that symlink is unwanted when source path changes."""
+        registry_path = tmp_path / "registry.json"
+        monkeypatch.setattr(
+            "haunt._registry.Registry.default_path", lambda cls: registry_path
+        )
+
+        old_package_dir = tmp_path / "old_package"
+        old_package_dir.mkdir()
+        new_package_dir = tmp_path / "new_package"
+        new_package_dir.mkdir()
+        target_dir = tmp_path / "target"
+        target_dir.mkdir()
+
+        # Create symlink pointing to old location
+        (old_package_dir / "file1.txt").write_text("old content")
+        (target_dir / "file1.txt").symlink_to(old_package_dir / "file1.txt")
+
+        # Set up registry with existing install pointing to old package
+        existing_symlinks = [
+            Symlink(
+                link_path=target_dir / "file1.txt",
+                source_path=old_package_dir / "file1.txt",
+            ),
+        ]
+
+        registry = Registry(path=registry_path)
+        registry.packages["package"] = PackageEntry(
+            name="package",
+            package_dir=old_package_dir,
+            target_dir=target_dir,
+            symlinks=existing_symlinks,
+            installed_at=datetime.now().astimezone().isoformat(),
+        )
+        registry.save()
+
+        # wanted symlinks point to new package (same link path, different source)
+        wanted_symlinks = [
+            Symlink(
+                link_path=target_dir / "file1.txt",
+                source_path=new_package_dir / "file1.txt",
+            ),
+        ]
+
+        result = find_unwanted_symlinks("package", wanted_symlinks)
+
+        # Old symlink should be unwanted even though path is wanted
+        assert len(result) == 1
+        assert result[0].link_path == target_dir / "file1.txt"
+        assert result[0].source_path == old_package_dir / "file1.txt"


### PR DESCRIPTION
Closes #2

## Summary

When a package is reinstalled, haunt now automatically removes symlinks that are no longer needed (because files were removed from the package).

Previously, users had to manually run `haunt uninstall` and `haunt install`. Now they can simply reinstall after adding or removing files from their package.

## Changes

**Core functionality:**
- Added `find_unwanted_symlinks()` to detect managed symlinks that are no longer wanted
- Added `check_package_name_collision()` helper for early collision detection
- Added `build_wanted_symlinks()` helper to build complete desired state
- Added `symlinks_to_remove` field to `InstallPlan`
- Added `wanted_symlinks` field to `InstallPlan` (all symlinks that should exist after install)
- `apply_install()` now removes unwanted symlinks before creating new ones

**User protection:**
- Only removes symlinks that still point to their expected target
- Won't remove symlinks that have been manually modified

**Tests:**
- Created `tests/operations/test_unwanted_symlinks.py` with 7 unit tests for `find_unwanted_symlinks()`
- Added unit tests in `test_install.py` for integration with planning and execution
- 100% coverage on all non-CLI code (137 tests total)

**Documentation:**
- Updated README to reflect simpler workflow (no need to uninstall when removing files)

## Test plan

- [x] All existing tests pass
- [x] New unit tests cover `find_unwanted_symlinks()` behavior
- [x] Integration tests verify planning and execution
- [x] Manual testing shows unwanted symlinks are removed on reinstall
- [x] Mypy type checking passes
- [x] Ruff linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)