### PR TITLE
Add autouse fixture to isolate registry in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+"""Global pytest configuration and fixtures."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def isolated_registry(tmp_path, monkeypatch):
+    """Automatically redirect Registry.default_path to tmp_path for all tests.
+
+    This ensures tests don't interfere with the user's real registry.
+    Tests that need to override this behavior can monkeypatch again.
+    """
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setattr(
+        "haunt._registry.Registry.default_path", lambda cls: registry_path
+    )

--- a/tests/operations/test_install.py
+++ b/tests/operations/test_install.py
@@ -312,11 +312,6 @@ class TestApplyInstall:
         package_dir = tmp_path / "package"
         target_dir = tmp_path / "target"
         target_dir.mkdir()
-        registry_path = tmp_path / "registry.json"
-        monkeypatch.setattr(
-            "haunt._registry.Registry.default_path", lambda cls: registry_path
-        )
-
         # Create a plan with symlinks to create
         symlinks = [
             Symlink(
@@ -351,11 +346,6 @@ class TestApplyInstall:
         package_dir = tmp_path / "package"
         target_dir = tmp_path / "target"
         target_dir.mkdir()
-        registry_path = tmp_path / "registry.json"
-        monkeypatch.setattr(
-            "haunt._registry.Registry.default_path", lambda cls: registry_path
-        )
-
         symlinks = [
             Symlink(
                 link_path=target_dir / "bashrc",
@@ -375,7 +365,7 @@ class TestApplyInstall:
         apply_install(plan)
 
         # Check registry was updated
-        registry = Registry(path=registry_path)
+        registry = Registry()
         assert "test-package" in registry.packages
         entry = registry.packages["test-package"]
         assert entry.name == "test-package"
@@ -389,11 +379,6 @@ class TestApplyInstall:
         package_dir = tmp_path / "package"
         target_dir = tmp_path / "target"
         target_dir.mkdir()
-        registry_path = tmp_path / "registry.json"
-        monkeypatch.setattr(
-            "haunt._registry.Registry.default_path", lambda cls: registry_path
-        )
-
         symlinks = [
             Symlink(
                 link_path=target_dir / "config" / "nvim" / "init.vim",
@@ -422,11 +407,6 @@ class TestApplyInstall:
         package_dir = tmp_path / "package"
         target_dir = tmp_path / "target"
         target_dir.mkdir()
-        registry_path = tmp_path / "registry.json"
-        monkeypatch.setattr(
-            "haunt._registry.Registry.default_path", lambda cls: registry_path
-        )
-
         plan = InstallPlan(
             package_name="test-package",
             package_dir=package_dir,
@@ -440,7 +420,7 @@ class TestApplyInstall:
         apply_install(plan)
 
         # Registry should still be updated
-        registry = Registry(path=registry_path)
+        registry = Registry()
         assert "test-package" in registry.packages
         assert registry.packages["test-package"].symlinks == []
 
@@ -449,11 +429,6 @@ class TestApplyInstall:
         package_dir = tmp_path / "package"
         target_dir = tmp_path / "target"
         target_dir.mkdir()
-        registry_path = tmp_path / "registry.json"
-        monkeypatch.setattr(
-            "haunt._registry.Registry.default_path", lambda cls: registry_path
-        )
-
         # Create plan with one new symlink and one already-correct
         new_symlink = Symlink(
             link_path=target_dir / "file1.txt",
@@ -484,7 +459,7 @@ class TestApplyInstall:
         apply_install(plan)
 
         # Check registry includes both symlinks
-        registry = Registry(path=registry_path)
+        registry = Registry()
         entry = registry.packages["test-package"]
         assert len(entry.symlinks) == 2
 
@@ -502,11 +477,6 @@ class TestApplyInstall:
         package_dir = tmp_path / "package"
         target_dir = tmp_path / "target"
         target_dir.mkdir()
-        registry_path = tmp_path / "registry.json"
-        monkeypatch.setattr(
-            "haunt._registry.Registry.default_path", lambda cls: registry_path
-        )
-
         plan = InstallPlan(
             package_name="test-package",
             package_dir=package_dir,
@@ -534,11 +504,6 @@ class TestApplyInstall:
         package_dir = tmp_path / "package"
         target_dir = tmp_path / "target"
         target_dir.mkdir()
-        registry_path = tmp_path / "registry.json"
-        monkeypatch.setattr(
-            "haunt._registry.Registry.default_path", lambda cls: registry_path
-        )
-
         plan = InstallPlan(
             package_name="test-package",
             package_dir=package_dir,
@@ -564,11 +529,6 @@ class TestApplyInstall:
         package_dir = tmp_path / "package"
         target_dir = tmp_path / "target"
         target_dir.mkdir()
-        registry_path = tmp_path / "registry.json"
-        monkeypatch.setattr(
-            "haunt._registry.Registry.default_path", lambda cls: registry_path
-        )
-
         plan = InstallPlan(
             package_name="test-package",
             package_dir=package_dir,
@@ -594,11 +554,6 @@ class TestApplyInstall:
         package_dir = tmp_path / "package"
         target_dir = tmp_path / "target"
         target_dir.mkdir()
-        registry_path = tmp_path / "registry.json"
-        monkeypatch.setattr(
-            "haunt._registry.Registry.default_path", lambda cls: registry_path
-        )
-
         plan = InstallPlan(
             package_name="test-package",
             package_dir=package_dir,
@@ -617,7 +572,7 @@ class TestApplyInstall:
         apply_install(plan, on_conflict=ConflictMode.SKIP)
 
         # Registry should still be updated
-        registry = Registry(path=registry_path)
+        registry = Registry()
         assert "test-package" in registry.packages
 
     def test_raises_for_package_name_collision(self, tmp_path, monkeypatch):
@@ -626,11 +581,6 @@ class TestApplyInstall:
         package_dir1 = tmp_path / "dotfiles1" / "shell"
         package_dir2 = tmp_path / "dotfiles2" / "shell"
         target_dir = tmp_path / "target"
-        registry_path = tmp_path / "registry.json"
-        monkeypatch.setattr(
-            "haunt._registry.Registry.default_path", lambda cls: registry_path
-        )
-
         # Install first package
         plan1 = InstallPlan(
             package_name="shell",
@@ -667,11 +617,6 @@ class TestApplyInstall:
         """Test reinstalling package from same path is allowed (idempotent)."""
         package_dir = tmp_path / "package"
         target_dir = tmp_path / "target"
-        registry_path = tmp_path / "registry.json"
-        monkeypatch.setattr(
-            "haunt._registry.Registry.default_path", lambda cls: registry_path
-        )
-
         # Install package
         plan1 = InstallPlan(
             package_name="package",
@@ -697,7 +642,7 @@ class TestApplyInstall:
         apply_install(plan2)  # Should not raise
 
         # Registry should still have the package
-        registry = Registry(path=registry_path)
+        registry = Registry()
         assert "package" in registry.packages
         assert registry.packages["package"].package_dir == package_dir
 
@@ -706,11 +651,6 @@ class TestApplyInstall:
         package_dir = tmp_path / "package"
         target_dir = tmp_path / "target"
         target_dir.mkdir()
-        registry_path = tmp_path / "registry.json"
-        monkeypatch.setattr(
-            "haunt._registry.Registry.default_path", lambda cls: registry_path
-        )
-
         # Create some unwanted symlinks that exist on disk
         unwanted_file1 = target_dir / "unwanted1.txt"
         unwanted_file2 = target_dir / "unwanted2.txt"

--- a/tests/operations/test_uninstall.py
+++ b/tests/operations/test_uninstall.py
@@ -24,11 +24,6 @@ class TestPlanUninstall:
         package_dir.mkdir()
         target_dir = tmp_path / "target"
         target_dir.mkdir()
-        registry_path = tmp_path / "registry.json"
-        monkeypatch.setattr(
-            "haunt._registry.Registry.default_path", lambda cls: registry_path
-        )
-
         # Create registry with package
         registry = Registry()
         registry.packages[package_dir.name] = PackageEntry(
@@ -71,11 +66,6 @@ class TestPlanUninstall:
         package_dir.mkdir()
         target_dir = tmp_path / "target"
         target_dir.mkdir()
-        registry_path = tmp_path / "registry.json"
-        monkeypatch.setattr(
-            "haunt._registry.Registry.default_path", lambda cls: registry_path
-        )
-
         # Create registry with package
         registry = Registry()
         registry.packages[package_dir.name] = PackageEntry(
@@ -110,11 +100,6 @@ class TestPlanUninstall:
         """Test that error is raised for unknown package."""
         package_dir = tmp_path / "nonexistent"
         package_dir.mkdir()
-        registry_path = tmp_path / "registry.json"
-        monkeypatch.setattr(
-            "haunt._registry.Registry.default_path", lambda cls: registry_path
-        )
-
         # Create empty registry
         registry = Registry()
         registry.save()
@@ -130,11 +115,6 @@ class TestPlanUninstall:
         package_dir.mkdir()
         target_dir = tmp_path / "target"
         target_dir.mkdir()
-        registry_path = tmp_path / "registry.json"
-        monkeypatch.setattr(
-            "haunt._registry.Registry.default_path", lambda cls: registry_path
-        )
-
         # Create registry with package
         registry = Registry()
         registry.packages[package_dir.name] = PackageEntry(
@@ -168,11 +148,6 @@ class TestPlanUninstall:
         package_dir.mkdir()
         target_dir = tmp_path / "target"
         target_dir.mkdir()
-        registry_path = tmp_path / "registry.json"
-        monkeypatch.setattr(
-            "haunt._registry.Registry.default_path", lambda cls: registry_path
-        )
-
         # Create registry with package
         registry = Registry()
         registry.packages[package_dir.name] = PackageEntry(
@@ -300,11 +275,6 @@ class TestApplyUninstall:
 
     def test_updates_registry(self, tmp_path, monkeypatch):
         """Test that package is removed from registry."""
-        registry_path = tmp_path / "registry.json"
-        monkeypatch.setattr(
-            "haunt._registry.Registry.default_path", lambda cls: registry_path
-        )
-
         # Mock registry
         mock_registry = Mock(spec=Registry)
         mock_registry.packages = {"test-package": Mock()}

--- a/tests/operations/test_unwanted_symlinks.py
+++ b/tests/operations/test_unwanted_symlinks.py
@@ -13,11 +13,6 @@ class TestFindUnwantedSymlinks:
 
     def test_returns_empty_when_package_not_in_registry(self, tmp_path, monkeypatch):
         """Test that no unwanted symlinks when package not in registry."""
-        registry_path = tmp_path / "registry.json"
-        monkeypatch.setattr(
-            "haunt._registry.Registry.default_path", lambda cls: registry_path
-        )
-
         package_dir = tmp_path / "package"
         target_dir = tmp_path / "target"
 
@@ -34,11 +29,6 @@ class TestFindUnwantedSymlinks:
 
     def test_returns_empty_when_no_unwanted(self, tmp_path, monkeypatch):
         """Test no unwanted symlinks when all old symlinks are still wanted."""
-        registry_path = tmp_path / "registry.json"
-        monkeypatch.setattr(
-            "haunt._registry.Registry.default_path", lambda cls: registry_path
-        )
-
         package_dir = tmp_path / "package"
         package_dir.mkdir()
         target_dir = tmp_path / "target"
@@ -62,7 +52,7 @@ class TestFindUnwantedSymlinks:
             ),
         ]
 
-        registry = Registry(path=registry_path)
+        registry = Registry()
         registry.packages["package"] = PackageEntry(
             name="package",
             package_dir=package_dir,
@@ -90,11 +80,6 @@ class TestFindUnwantedSymlinks:
 
     def test_finds_unwanted_symlink_when_file_removed(self, tmp_path, monkeypatch):
         """Test that unwanted symlink is found when file removed from package."""
-        registry_path = tmp_path / "registry.json"
-        monkeypatch.setattr(
-            "haunt._registry.Registry.default_path", lambda cls: registry_path
-        )
-
         package_dir = tmp_path / "package"
         package_dir.mkdir()
         target_dir = tmp_path / "target"
@@ -116,7 +101,7 @@ class TestFindUnwantedSymlinks:
             ),
         ]
 
-        registry = Registry(path=registry_path)
+        registry = Registry()
         registry.packages["package"] = PackageEntry(
             name="package",
             package_dir=package_dir,
@@ -141,11 +126,6 @@ class TestFindUnwantedSymlinks:
 
     def test_does_not_include_modified_symlinks(self, tmp_path, monkeypatch):
         """Test that modified symlinks are not returned as unwanted."""
-        registry_path = tmp_path / "registry.json"
-        monkeypatch.setattr(
-            "haunt._registry.Registry.default_path", lambda cls: registry_path
-        )
-
         package_dir = tmp_path / "package"
         package_dir.mkdir()
         target_dir = tmp_path / "target"
@@ -164,7 +144,7 @@ class TestFindUnwantedSymlinks:
             ),
         ]
 
-        registry = Registry(path=registry_path)
+        registry = Registry()
         registry.packages["package"] = PackageEntry(
             name="package",
             package_dir=package_dir,
@@ -184,11 +164,6 @@ class TestFindUnwantedSymlinks:
 
     def test_wanted_symlinks_not_considered_unwanted(self, tmp_path, monkeypatch):
         """Test that symlinks in wanted set aren't considered unwanted."""
-        registry_path = tmp_path / "registry.json"
-        monkeypatch.setattr(
-            "haunt._registry.Registry.default_path", lambda cls: registry_path
-        )
-
         package_dir = tmp_path / "package"
         package_dir.mkdir()
         target_dir = tmp_path / "target"
@@ -206,7 +181,7 @@ class TestFindUnwantedSymlinks:
             ),
         ]
 
-        registry = Registry(path=registry_path)
+        registry = Registry()
         registry.packages["package"] = PackageEntry(
             name="package",
             package_dir=package_dir,
@@ -231,11 +206,6 @@ class TestFindUnwantedSymlinks:
 
     def test_handles_multiple_unwanted(self, tmp_path, monkeypatch):
         """Test finding multiple unwanted symlinks at once."""
-        registry_path = tmp_path / "registry.json"
-        monkeypatch.setattr(
-            "haunt._registry.Registry.default_path", lambda cls: registry_path
-        )
-
         package_dir = tmp_path / "package"
         package_dir.mkdir()
         target_dir = tmp_path / "target"
@@ -255,7 +225,7 @@ class TestFindUnwantedSymlinks:
             for i in range(1, 4)
         ]
 
-        registry = Registry(path=registry_path)
+        registry = Registry()
         registry.packages["package"] = PackageEntry(
             name="package",
             package_dir=package_dir,
@@ -284,11 +254,6 @@ class TestFindUnwantedSymlinks:
 
     def test_detects_unwanted_when_source_changes(self, tmp_path, monkeypatch):
         """Test that symlink is unwanted when source path changes."""
-        registry_path = tmp_path / "registry.json"
-        monkeypatch.setattr(
-            "haunt._registry.Registry.default_path", lambda cls: registry_path
-        )
-
         old_package_dir = tmp_path / "old_package"
         old_package_dir.mkdir()
         new_package_dir = tmp_path / "new_package"
@@ -308,7 +273,7 @@ class TestFindUnwantedSymlinks:
             ),
         ]
 
-        registry = Registry(path=registry_path)
+        registry = Registry()
         registry.packages["package"] = PackageEntry(
             name="package",
             package_dir=old_package_dir,

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+import haunt._registry
 from haunt._registry import REGISTRY_VERSION
 from haunt._registry import Registry
 from haunt.exceptions import RegistryValidationError
@@ -19,11 +20,10 @@ class TestDefaultPath:
 
     def test_default_path_calls_user_state_path(self, monkeypatch, tmp_path):
         """Test that default_path calls user_state_path('haunt')."""
+        # Undo the autouse fixture monkeypatch to test the real implementation
+        monkeypatch.undo()
+
         mock_user_state_path = MagicMock(return_value=tmp_path / "haunt_state")
-
-        # Mock platformdirs.user_state_path
-        import haunt._registry
-
         monkeypatch.setattr(haunt._registry, "user_state_path", mock_user_state_path)
 
         result = Registry.default_path()


### PR DESCRIPTION
Closes #23

## Summary

Created a global autouse fixture that automatically isolates the registry for all tests, eliminating 28 duplicate monkeypatch calls across the test suite.

## Changes

**New file:**
- `tests/conftest.py` with `isolated_registry` autouse fixture that redirects `Registry.default_path()` to `tmp_path / "registry.json"`

**Cleanup:**
- Removed 28 manual `monkeypatch.setattr("haunt._registry.Registry.default_path", ...)` calls
- Removed now-unused `registry_path` variable definitions  
- Replaced `Registry(path=registry_path)` with `Registry()` to use default path
- Updated one test that needs to test the real `default_path()` to call `monkeypatch.undo()`
- Moved `import haunt._registry` to top of test_registry.py

## Benefits

1. **Less boilerplate**: 28 fewer monkeypatch calls means cleaner, more focused tests
2. **Safety**: All tests are automatically isolated from user's real registry
3. **Consistency**: Single source of truth for test registry isolation
4. **Flexibility**: Tests that need different behavior can still override with their own monkeypatch

## Test plan

- [x] All 137 tests pass
- [x] Tests still use isolated tmp_path registry
- [x] `test_default_path_calls_user_state_path` can still test the real implementation
- [x] Pre-commit hooks pass
- [x] Ruff linting passes
- [x] Mypy type checking passes (on src/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)