### PR TITLE
Document package naming convention for uninstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The files in the package are symlinked from your home folder, and existing files
             └── init.lua
 ```
 
-Uninstall the package:
+Uninstall the package (using the package name, which is the directory basename):
 ```bash
 $ haunt uninstall dotfiles
 Removing symlinks:
@@ -70,6 +70,8 @@ Removing symlinks:
 
 2 symlinks removed
 ```
+
+To see all installed packages, use `haunt list`.
 
 ## Commands
 
@@ -95,6 +97,8 @@ haunt uninstall [OPTIONS] PACKAGE
 
 - `PACKAGE` - package name to uninstall (required)
 - `--dry-run, -n` - show what would happen without doing it
+
+**Package names** are derived from the directory basename. For example, `haunt install ~/dotfiles` creates a package named `dotfiles`. To see all installed packages, use `haunt list`.
 
 ### `haunt list`
 


### PR DESCRIPTION
Closes #21

## Summary

Clarified in the README that package names are derived from directory basenames and directed users to `haunt list` to see installed packages. This addresses the discoverability issue without requiring code changes (option 2 from the issue).

## Changes

**Quickstart section:**
- Added explanation that uninstall uses the package name (directory basename)
- Added pointer to `haunt list` command for viewing installed packages

**Commands section (`haunt uninstall`):**
- Added note explaining package naming convention with example
- Directed users to `haunt list` to see all installed packages

## Why This Approach

This documentation-only solution:
1. **Clarifies the naming convention** upfront so users understand the relationship between install path and package name
2. **Points to existing tooling** (`haunt list`) that already solves the discovery problem
3. **Requires no code changes** or new features
4. **Maintains consistency** with how packages are conceptually identified throughout the codebase

## Example Flow

After this change, a confused user will:
1. Read in Quickstart: "Uninstall the package (using the package name, which is the directory basename)"
2. See the example: `haunt install ~/dotfiles` → `haunt uninstall dotfiles`
3. Learn: "To see all installed packages, use `haunt list`"

Or if they go straight to the command documentation:
1. Read: "Package names are derived from the directory basename"
2. See example: `haunt install ~/dotfiles` creates package named `dotfiles`
3. Learn: "To see all installed packages, use `haunt list`"

## Test plan

- [x] All tests pass (documentation-only change)
- [x] Pre-commit hooks pass
- [x] README changes are clear and accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)