### PR TITLE
Refactor: deduplicate CLI errors and simplify path helpers

### DIFF
--- a/src/haunt/_cli/cli.py
+++ b/src/haunt/_cli/cli.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 from typing import Annotated
+from typing import NoReturn
 
 import typer
 
@@ -24,6 +25,14 @@ from haunt.operations import plan_install
 from haunt.operations import plan_uninstall
 
 app = typer.Typer(help="Symlink dotfiles manager")
+
+
+def _fatal(msg: str, *extra: str) -> NoReturn:
+    """Print red bold error to stderr, optional extra lines, and exit 1."""
+    typer.secho(f"✗ {msg}", fg=typer.colors.RED, bold=True, err=True)
+    for line in extra:
+        typer.secho(f"   {line}", err=True)
+    raise typer.Exit(1)
 
 
 def version_callback(value: bool) -> None:
@@ -65,6 +74,10 @@ def install(
     if target is None:
         target = Path.home()
 
+    partial_warning = (
+        "Warning: Package may be partially installed. "
+        "Check filesystem and registry manually."
+    )
     try:
         plan = plan_install(package, target, on_conflict=on_conflict)
         print_install_plan(plan, on_conflict=on_conflict, dry_run=dry_run)
@@ -72,48 +85,25 @@ def install(
         if not dry_run:
             apply_install(plan, on_conflict=on_conflict)
     except PackageAlreadyInstalledError as e:
-        typer.secho(f"✗ {e}", fg=typer.colors.RED, bold=True, err=True)
-        raise typer.Exit(1) from None
+        _fatal(str(e))
     except ConflictError as e:
         print_conflict_error(e, on_conflict)
         raise typer.Exit(1) from None
     except (RegistryValidationError, RegistryVersionError) as e:
-        typer.secho(f"✗ Registry error: {e}", fg=typer.colors.RED, bold=True, err=True)
-        raise typer.Exit(1) from None
+        _fatal(f"Registry error: {e}")
     except PermissionError as e:
-        typer.secho(
-            f"✗ Permission denied: {e}", fg=typer.colors.RED, bold=True, err=True
-        )
-        raise typer.Exit(1) from None
+        _fatal(f"Permission denied: {e}")
     except FileExistsError as e:
-        typer.secho(
-            f"✗ File exists (filesystem changed between planning and execution): {e}",
-            fg=typer.colors.RED,
-            bold=True,
-            err=True,
+        _fatal(
+            f"File exists (filesystem changed between planning and execution): {e}",
+            partial_warning,
         )
-        typer.secho(
-            "   Warning: Package may be partially installed. Check "
-            "filesystem and registry manually.",
-            err=True,
-        )
-        raise typer.Exit(1) from None
     except ValueError as e:
-        typer.secho(f"✗ {e}", fg=typer.colors.RED, bold=True, err=True)
-        raise typer.Exit(1) from None
+        _fatal(str(e))
     except OSError as e:
-        typer.secho(
-            f"✗ Filesystem error: {e}", fg=typer.colors.RED, bold=True, err=True
-        )
-        typer.secho(
-            "   Warning: Package may be partially installed. Check "
-            "filesystem and registry manually.",
-            err=True,
-        )
-        raise typer.Exit(1) from None
+        _fatal(f"Filesystem error: {e}", partial_warning)
     except HauntError as e:
-        typer.secho(f"✗ Error: {e}", fg=typer.colors.RED, bold=True, err=True)
-        raise typer.Exit(1) from None
+        _fatal(f"Error: {e}")
 
 
 @app.command()
@@ -132,14 +122,11 @@ def list(
         registry = Registry()
         print_package_list(registry, package_name=package, verbose=verbose)
     except PackageNotFoundError as e:
-        typer.secho(f"✗ {e}", fg=typer.colors.RED, bold=True, err=True)
-        raise typer.Exit(1) from None
+        _fatal(str(e))
     except (RegistryValidationError, RegistryVersionError) as e:
-        typer.secho(f"✗ Registry error: {e}", fg=typer.colors.RED, bold=True, err=True)
-        raise typer.Exit(1) from None
+        _fatal(f"Registry error: {e}")
     except HauntError as e:
-        typer.secho(f"✗ Error: {e}", fg=typer.colors.RED, bold=True, err=True)
-        raise typer.Exit(1) from None
+        _fatal(f"Error: {e}")
 
 
 @app.command()
@@ -157,29 +144,19 @@ def uninstall(
         if not dry_run:
             apply_uninstall(plan)
     except PackageNotFoundError as e:
-        typer.secho(f"✗ {e}", fg=typer.colors.RED, bold=True, err=True)
-        raise typer.Exit(1) from None
+        _fatal(str(e))
     except (RegistryValidationError, RegistryVersionError) as e:
-        typer.secho(f"✗ Registry error: {e}", fg=typer.colors.RED, bold=True, err=True)
-        raise typer.Exit(1) from None
+        _fatal(f"Registry error: {e}")
     except PermissionError as e:
-        typer.secho(
-            f"✗ Permission denied: {e}", fg=typer.colors.RED, bold=True, err=True
-        )
-        raise typer.Exit(1) from None
+        _fatal(f"Permission denied: {e}")
     except OSError as e:
-        typer.secho(
-            f"✗ Filesystem error: {e}", fg=typer.colors.RED, bold=True, err=True
+        _fatal(
+            f"Filesystem error: {e}",
+            "Warning: Package may be partially uninstalled. "
+            "Check filesystem and registry manually.",
         )
-        typer.secho(
-            "   Warning: Package may be partially uninstalled. Check "
-            "filesystem and registry manually.",
-            err=True,
-        )
-        raise typer.Exit(1) from None
     except HauntError as e:
-        typer.secho(f"✗ Error: {e}", fg=typer.colors.RED, bold=True, err=True)
-        raise typer.Exit(1) from None
+        _fatal(f"Error: {e}")
 
 
 def main() -> None:

--- a/src/haunt/_cli/output.py
+++ b/src/haunt/_cli/output.py
@@ -226,7 +226,7 @@ def print_package_list(
             dt = datetime.fromisoformat(entry.installed_at)
             local_dt = dt.astimezone()
             timestamp = local_dt.strftime("%Y-%m-%d %H:%M:%S")
-        except (ValueError, AttributeError):
+        except ValueError:
             timestamp = entry.installed_at
         typer.echo(f"  Installed: {timestamp}")
 
@@ -285,12 +285,10 @@ def print_package_list(
                 for symlink_str, color in inconsistent_symlinks:
                     typer.secho(f"      {symlink_str}", fg=color)
 
-                package_dir_display = _display_path(entry.package_dir)
-                target_dir_display = _display_path(entry.target_dir)
                 typer.echo()
                 typer.secho("  To fix inconsistent symlinks:", fg=typer.colors.YELLOW)
                 typer.secho(
-                    f"    haunt install {package_dir_display} {target_dir_display}",
+                    f"    haunt install {package_display} {target_display}",
                     fg=typer.colors.YELLOW,
                 )
 

--- a/src/haunt/_files/cleanup.py
+++ b/src/haunt/_files/cleanup.py
@@ -23,32 +23,21 @@ def remove_empty_directories(target_dir: Path, file_paths: list[Path]) -> list[P
     checked = set()  # Track directories we've already processed
 
     for file_path in file_paths:
-        # Validate that file_path is under target_dir
-        try:
-            file_path.relative_to(target_dir)
-        except ValueError as e:
-            raise ValueError(f"{file_path} is not under {target_dir}") from e
+        if not file_path.is_relative_to(target_dir):
+            raise ValueError(f"{file_path} is not under {target_dir}")
 
-        # Get the parent directory of this file
         current = file_path.parent
-
-        # Walk up the directory tree
         while current != target_dir:
-            # Skip if we've already checked this directory
             if current in checked:
                 break
             checked.add(current)
 
-            if not current.exists():
-                break
-
-            # Try to remove the directory (only works if empty)
             try:
                 current.rmdir()
                 removed.append(current)
                 current = current.parent
             except OSError:
-                # Directory not empty, stop walking up this branch
+                # Directory not empty or doesn't exist, stop walking up
                 break
 
     return removed

--- a/src/haunt/_files/paths.py
+++ b/src/haunt/_files/paths.py
@@ -26,18 +26,6 @@ def normalize_package_dir(package_dir: Path) -> Path:
     return package_dir
 
 
-def normalize_target_dir(target_dir: Path) -> Path:
-    """Normalize target directory path to absolute.
-
-    Args:
-        target_dir: Directory where symlinks will be created
-
-    Returns:
-        Absolute path to target directory
-    """
-    return target_dir.resolve()
-
-
 def validate_install_directories(package_dir: Path, target_dir: Path) -> None:
     """Validate that package and target directories have a valid relationship.
 

--- a/src/haunt/_files/symlinks.py
+++ b/src/haunt/_files/symlinks.py
@@ -19,7 +19,7 @@ def check_conflict(symlink: Symlink) -> Conflict | None:
         Conflict if something exists at link_path, None if nothing exists.
         CorrectSymlinkConflict means symlink exists and points correctly.
     """
-    if not symlink.link_path.exists() and not symlink.link_path.is_symlink():
+    if symlink.is_missing():
         return None
 
     # Handle symlinks (including broken)
@@ -96,8 +96,7 @@ def create_symlink(symlink: Symlink, force: bool = False) -> None:
             )
 
         # Remove existing file or symlink if present (unlink removes link, not target)
-        if symlink.link_path.exists() or symlink.link_path.is_symlink():
-            symlink.link_path.unlink()
+        symlink.link_path.unlink(missing_ok=True)
 
     symlink.link_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/src/haunt/operations/__init__.py
+++ b/src/haunt/operations/__init__.py
@@ -1,7 +1,5 @@
 """High-level operations for haunt."""
 
-from haunt._files.paths import normalize_package_dir
-from haunt._files.paths import normalize_target_dir
 from haunt.operations.install import apply_install
 from haunt.operations.install import plan_install
 from haunt.operations.uninstall import apply_uninstall
@@ -12,6 +10,4 @@ __all__ = [
     "plan_uninstall",
     "apply_install",
     "apply_uninstall",
-    "normalize_package_dir",
-    "normalize_target_dir",
 ]

--- a/src/haunt/operations/install.py
+++ b/src/haunt/operations/install.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 from haunt._files.discover import discover_files
 from haunt._files.paths import normalize_package_dir
-from haunt._files.paths import normalize_target_dir
 from haunt._files.paths import validate_install_directories
 from haunt._files.symlinks import check_conflict
 from haunt._files.symlinks import create_symlink
@@ -93,7 +92,7 @@ def plan_install(
         PackageAlreadyInstalledError: If package name exists from different directory
     """
     package_dir = normalize_package_dir(package_dir)
-    target_dir = normalize_target_dir(target_dir)
+    target_dir = target_dir.resolve()
     validate_install_directories(package_dir, target_dir)
 
     package_name = package_dir.name

--- a/src/haunt/operations/uninstall.py
+++ b/src/haunt/operations/uninstall.py
@@ -32,7 +32,7 @@ def plan_uninstall(package_name: str) -> UninstallPlan:
     modified_symlinks = []
 
     for symlink in entry.symlinks:
-        if not symlink.link_path.exists(follow_symlinks=False):
+        if symlink.is_missing():
             missing_symlinks.append(symlink.link_path)
         elif symlink.exists():
             symlinks_to_remove.append(symlink)

--- a/tests/operations/test_paths.py
+++ b/tests/operations/test_paths.py
@@ -4,9 +4,8 @@ from pathlib import Path
 
 import pytest
 
+from haunt._files.paths import normalize_package_dir
 from haunt._files.paths import validate_install_directories
-from haunt.operations import normalize_package_dir
-from haunt.operations import normalize_target_dir
 
 
 class TestNormalizePackageDir:
@@ -50,43 +49,6 @@ class TestNormalizePackageDir:
 
         with pytest.raises(NotADirectoryError, match="not a directory"):
             normalize_package_dir(package_file)
-
-
-class TestNormalizeTargetDir:
-    """Tests for normalize_target_dir()."""
-
-    def test_resolves_to_absolute_path(self, tmp_path):
-        """Test that relative paths are resolved to absolute."""
-        target_dir = tmp_path / "target"
-        target_dir.mkdir()
-
-        # Use relative path
-        import os
-
-        os.chdir(tmp_path)
-        result = normalize_target_dir(Path("target"))
-
-        assert result.is_absolute()
-        assert result == target_dir.resolve()
-
-    def test_already_absolute_path_unchanged(self, tmp_path):
-        """Test that absolute paths are resolved (may resolve symlinks)."""
-        target_dir = tmp_path / "target"
-        target_dir.mkdir()
-
-        result = normalize_target_dir(target_dir)
-
-        assert result.is_absolute()
-        assert result == target_dir.resolve()
-
-    def test_does_not_validate_existence(self, tmp_path):
-        """Test that target_dir is not validated for existence."""
-        nonexistent = tmp_path / "nonexistent"
-
-        # Should not raise
-        result = normalize_target_dir(nonexistent)
-
-        assert result.is_absolute()
 
 
 class TestValidateInstallDirectories:


### PR DESCRIPTION
## Summary
- Adds a `_fatal()` helper in the CLI to consolidate the repeated "print red error and exit(1)" pattern across install/list/uninstall handlers
- Removes the trivial `normalize_target_dir()` wrapper and its tests — callers now use `Path.resolve()` directly; also drops the re-exports from `operations.__init__`
- Tightens small things: `Path.is_relative_to()` over try/except, `unlink(missing_ok=True)`, `symlink.is_missing()` helper usage, narrower `except ValueError` for timestamp parsing, and reusing already-computed display paths in the suggestion output

## Test plan
- [ ] `uv run pytest --cov=haunt --cov-report=term-missing`
- [ ] Manually exercise `haunt install` with a bad package path and confirm red `✗` error + non-zero exit
- [ ] Trigger a conflict during install and confirm the partial-install warning extra lines render under the error